### PR TITLE
Fix Class.unwrapThrowable potential infinite loop

### DIFF
--- a/src/main/java/com/ibatis/common/beans/ClassInfo.java
+++ b/src/main/java/com/ibatis/common/beans/ClassInfo.java
@@ -539,7 +539,7 @@ public class ClassInfo {
     while (true) {
       if (t2 instanceof InvocationTargetException) {
         t2 = ((InvocationTargetException) t).getTargetException();
-      } else if (t instanceof UndeclaredThrowableException) {
+      } else if (t2 instanceof UndeclaredThrowableException) {
         t2 = ((UndeclaredThrowableException) t).getUndeclaredThrowable();
       } else {
         return t2;

--- a/src/test/java/com/ibatis/common/beans/BadBeanTest.java
+++ b/src/test/java/com/ibatis/common/beans/BadBeanTest.java
@@ -1,5 +1,7 @@
 package com.ibatis.common.beans;
 
+import java.lang.reflect.UndeclaredThrowableException;
+import java.sql.SQLException;
 import junit.framework.TestCase;
 import badbeans.*;
 
@@ -65,6 +67,12 @@ public class BadBeanTest extends TestCase {
     } catch (Exception e) {
       //ignore
     }
+  }
+
+  public void testUnwrapThrowable() {
+    SQLException cause = new SQLException("test");
+    UndeclaredThrowableException e = new UndeclaredThrowableException(cause);
+    assertEquals(cause, ClassInfo.unwrapThrowable(e));
   }
 
 }


### PR DESCRIPTION
ClasInfo.unwrapThroable will infinite loop when argument provide UndeclaredThrowableException.