### PR TITLE
Fix bugs that prevented replicated ehcache from working.

### DIFF
--- a/src/main/java/com/ibatis/sqlmap/engine/cache/CacheKey.java
+++ b/src/main/java/com/ibatis/sqlmap/engine/cache/CacheKey.java
@@ -15,13 +15,14 @@
  */
 package com.ibatis.sqlmap.engine.cache;
 
+import java.io.Serializable;
 import java.util.List;
 import java.util.ArrayList;
 
 /**
  * Hash value generator for cache keys
  */
-public class CacheKey {
+public class CacheKey  implements Cloneable, Serializable {
 
   private static final int DEFAULT_MULTIPLYER = 37;
   private static final int DEFAULT_HASHCODE = 17;
@@ -130,5 +131,11 @@ public class CacheKey {
 
     return returnValue.toString();
   }
+
+    public CacheKey clone() throws CloneNotSupportedException {
+        CacheKey clonedCacheKey = (CacheKey) super.clone();
+        clonedCacheKey.paramList = new ArrayList<Object>(paramList);
+        return clonedCacheKey;
+    }
 
 }


### PR DESCRIPTION
I was unable to get a replicated ehcache webapp that I work on to replicate properly.  After debugging I was able to make some small code changes to get it working.

First I made CacheKey Serializable, that got my cache cluster to replicate, but didn't get any replicated cache hits when I failed my system over.

Second I removed the cacheKey.update(baseCachKey) method call in the getCacheKey method, and that allowed my system to then get replicated cache hits after I forced a fail over with my load balancer.  The issue here was the baseCacheKey uses object.hashCode(), and the value is different on different hosts as per the java implementation and this is not desired in the CacheKey impl.