### PR TITLE
Fixed an issue with useSetObjectForNullValue due to mssql jdbcdrivername change

### DIFF
--- a/src/main/java/com/ibatis/sqlmap/engine/mapping/parameter/ParameterMap.java
+++ b/src/main/java/com/ibatis/sqlmap/engine/mapping/parameter/ParameterMap.java
@@ -333,7 +333,7 @@ public class ParameterMap {
             DatabaseMetaData dbmd = ps.getConnection().getMetaData();
             String databaseProductName = dbmd.getDatabaseProductName();
             String jdbcDriverName = dbmd.getDriverName();
-            if (databaseProductName.startsWith("Informix") || jdbcDriverName.startsWith("Microsoft SQL Server")) {
+            if (databaseProductName.startsWith("Informix") || databaseProductName.startsWith("Microsoft SQL Server")) {
               useSetObjectForNullValue = Boolean.TRUE;
             } else if (databaseProductName.startsWith("DB2") || jdbcDriverName.startsWith("jConnect")
                 || jdbcDriverName.startsWith("SQLServer") || jdbcDriverName.startsWith("Apache Derby Embedded")) {


### PR DESCRIPTION
Hello, Thank you for maintaining ibatis-2 legacy version. Unfortunately we are not able to migrate to latest mybatis. and we are stuck with ibatis for some more time. Found an issue with mssql-jdbc and ibatis2. 

**Issue:** `useSetObjectForNullValue` is not set properly for MSSQL JDBC driver. 
**Reason:** `jdbcDriverName` doesn't start with `Microsoft SQL Server`. https://github.com/microsoft/mssql-jdbc/blob/master/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerDriver.java#L445

https://github.com/microsoft/mssql-jdbc/blob/master/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerDatabaseMetaData.java#L982

**Fix:** use `databaseProductName` instead. https://github.com/microsoft/mssql-jdbc/blob/master/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerDatabaseMetaData.java#L954