### PR TITLE
Improve build performance by turning off report generation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -74,6 +74,7 @@
     <osgi.dynamicImport>*</osgi.dynamicImport>
     <signature.artifact>java17</signature.artifact>
     <signature.version>1.0</signature.version>
+  	<closeTestReports>true</closeTestReports>
   </properties>
 
   <dependencies>
@@ -185,6 +186,7 @@
               <value>${project.build.directory}/ibderby</value>
             </property>
           </systemProperties>
+        	<disableXmlReport>${closeTestReports}</disableXmlReport>
         </configuration>
       </plugin>
     </plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -74,7 +74,7 @@
     <osgi.dynamicImport>*</osgi.dynamicImport>
     <signature.artifact>java17</signature.artifact>
     <signature.version>1.0</signature.version>
-  	<closeTestReports>true</closeTestReports>
+    <closeTestReports>true</closeTestReports>
   </properties>
 
   <dependencies>
@@ -186,7 +186,7 @@
               <value>${project.build.directory}/ibderby</value>
             </property>
           </systemProperties>
-        	<disableXmlReport>${closeTestReports}</disableXmlReport>
+          <disableXmlReport>${closeTestReports}</disableXmlReport>
         </configuration>
       </plugin>
     </plugins>


### PR DESCRIPTION

That report generation takes time, slowing down the overall build. Reports are definitely useful, but do you need them every time you run the build. We can conditionally disable generating test reports by setting `<disableXmlReport>true<disableXmlReport>`. If you need to generate reports, just add `-DcloseTestReports=false` to the end of mvn build command.

=====================
If there are any inappropriate modifications in this PR, please give me a reply and I will change them.
