### PR TITLE
Fix code scanning alert no. 4: Resolving XML external entity in user-controlled data

### DIFF
--- a/src/main/java/com/ibatis/common/xml/NodeletParser.java
+++ b/src/main/java/com/ibatis/common/xml/NodeletParser.java
@@ -254,7 +254,7 @@ public class NodeletParser {
     factory.setIgnoringComments(true);
     factory.setIgnoringElementContentWhitespace(false);
     factory.setCoalescing(false);
-    factory.setExpandEntityReferences(true);
+    factory.setExpandEntityReferences(false);
 
     DocumentBuilder builder = factory.newDocumentBuilder();
     builder.setEntityResolver(entityResolver);


### PR DESCRIPTION
Fixes [https://github.com/mybatis/ibatis-2/security/code-scanning/4](https://github.com/mybatis/ibatis-2/security/code-scanning/4)

To fix the problem, we need to disable the expansion of external entities by setting `setExpandEntityReferences(false)` on the `DocumentBuilderFactory`. This change will prevent the parser from resolving external entities, thus mitigating the risk of XXE attacks.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
