### PR TITLE
Fix code scanning alert no. 3: Resolving XML external entity in user-controlled data

### DIFF
--- a/src/main/java/com/ibatis/common/xml/NodeletParser.java
+++ b/src/main/java/com/ibatis/common/xml/NodeletParser.java
@@ -199,13 +199,16 @@ public class NodeletParser {
     factory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
     factory.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, "");
     factory.setAttribute(XMLConstants.ACCESS_EXTERNAL_SCHEMA, "");
+    factory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
+    factory.setFeature("http://xml.org/sax/features/external-general-entities", false);
+    factory.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
     factory.setValidating(validation);
 
     factory.setNamespaceAware(false);
     factory.setIgnoringComments(true);
     factory.setIgnoringElementContentWhitespace(false);
     factory.setCoalescing(false);
-    factory.setExpandEntityReferences(true);
+    factory.setExpandEntityReferences(false);
 
     DocumentBuilder builder = factory.newDocumentBuilder();
     builder.setEntityResolver(entityResolver);

--- a/src/main/java/com/ibatis/common/xml/NodeletParser.java
+++ b/src/main/java/com/ibatis/common/xml/NodeletParser.java
@@ -199,9 +199,6 @@ public class NodeletParser {
     factory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
     factory.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, "");
     factory.setAttribute(XMLConstants.ACCESS_EXTERNAL_SCHEMA, "");
-    factory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
-    factory.setFeature("http://xml.org/sax/features/external-general-entities", false);
-    factory.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
     factory.setValidating(validation);
 
     factory.setNamespaceAware(false);


### PR DESCRIPTION
Fixes [https://github.com/mybatis/ibatis-2/security/code-scanning/3](https://github.com/mybatis/ibatis-2/security/code-scanning/3)

To fix the problem, we need to disable the parsing of external entities and DTDs explicitly. This can be done by setting the `setFeature` method on the `DocumentBuilderFactory` to disallow DOCTYPE declarations and external entities. Additionally, we should set `setExpandEntityReferences(false)` to prevent the expansion of entity references.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
