### PR TITLE
Fix code scanning alert no. 3: Resolving XML external entity in user-controlled data

### DIFF
--- a/src/main/java/com/ibatis/common/xml/NodeletParser.java
+++ b/src/main/java/com/ibatis/common/xml/NodeletParser.java
@@ -197,6 +197,9 @@ public class NodeletParser {
       throws ParserConfigurationException, FactoryConfigurationError, SAXException, IOException {
     DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
     factory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
+    factory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
+    factory.setFeature("http://xml.org/sax/features/external-general-entities", false);
+    factory.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
     factory.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, "");
     factory.setAttribute(XMLConstants.ACCESS_EXTERNAL_SCHEMA, "");
     factory.setValidating(validation);

--- a/src/main/java/com/ibatis/common/xml/NodeletParser.java
+++ b/src/main/java/com/ibatis/common/xml/NodeletParser.java
@@ -197,8 +197,7 @@ public class NodeletParser {
       throws ParserConfigurationException, FactoryConfigurationError, SAXException, IOException {
     DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
     factory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
-    factory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
-    factory.setFeature("http://xml.org/sax/features/external-general-entities", false);
+     factory.setFeature("http://xml.org/sax/features/external-general-entities", false);
     factory.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
     factory.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, "");
     factory.setAttribute(XMLConstants.ACCESS_EXTERNAL_SCHEMA, "");


### PR DESCRIPTION
Fixes [https://github.com/mybatis/ibatis-2/security/code-scanning/3](https://github.com/mybatis/ibatis-2/security/code-scanning/3)

To fix the problem, we need to ensure that the XML parser is fully secured against XXE attacks by disabling the parsing of external entities. This involves setting additional features on the `DocumentBuilderFactory` to disallow DOCTYPE declarations and external entities.

1. Disable DOCTYPE declarations by setting the feature `http://apache.org/xml/features/disallow-doctype-decl` to `true`.
2. Ensure that external entities are not processed by setting the feature `http://xml.org/sax/features/external-general-entities` and `http://xml.org/sax/features/external-parameter-entities` to `false`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
