### PR TITLE
Fix code scanning alert no. 4: Resolving XML external entity in user-controlled data

### DIFF
--- a/src/main/java/com/ibatis/common/xml/NodeletParser.java
+++ b/src/main/java/com/ibatis/common/xml/NodeletParser.java
@@ -248,6 +248,9 @@ public class NodeletParser {
       throws ParserConfigurationException, FactoryConfigurationError, SAXException, IOException {
     DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
     factory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
+    factory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
+    factory.setFeature("http://xml.org/sax/features/external-general-entities", false);
+    factory.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
     factory.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, "");
     factory.setAttribute(XMLConstants.ACCESS_EXTERNAL_SCHEMA, "");
     factory.setValidating(validation);


### PR DESCRIPTION
Fixes [https://github.com/mybatis/ibatis-2/security/code-scanning/4](https://github.com/mybatis/ibatis-2/security/code-scanning/4)

To fix the problem, we need to ensure that the XML parser is fully secured against XXE attacks by explicitly disabling external entity resolution. This involves setting the appropriate features on the `DocumentBuilderFactory` to prevent the parser from resolving external entities.

1. Modify the `createDocument` method in `NodeletParser` to disable external entity resolution.
2. Add the necessary feature settings to the `DocumentBuilderFactory` to ensure that external entities are not processed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
