### PR TITLE
[gha] Run cleanup without the keep option as that is misleading

### DIFF
--- a/.github/workflows/cleanup.yaml
+++ b/.github/workflows/cleanup.yaml
@@ -17,7 +17,6 @@ jobs:
     steps:
       - uses: Mattraks/delete-workflow-runs@5bf9a1dac5c4d041c029f0a8370ddf0c5cb5aeb7 #v2
         with:
-          keep_minimum_runs: 3
           repository: ${{ github.repository }}
           retain_days: 30
           token: ${{ github.token }}


### PR DESCRIPTION
retain of 30 days is fine, we use renovate so there is practically always something.  The retain logic I expected to just keep 3 if it had been more than 30 days since running but what it did was keep 30 days + 3 extra which I find useless.  I've never needed to go back through history to see what the runs did.  I only care so much that they are working and the returns of failures fall off fast, this at least cuts down on noise that needlessly takes space from allowable usage on github OSS.