### PR TITLE
Remove duplicate null check

### DIFF
--- a/src/main/java/com/ibatis/sqlmap/engine/config/MappedStatementConfig.java
+++ b/src/main/java/com/ibatis/sqlmap/engine/config/MappedStatementConfig.java
@@ -132,7 +132,7 @@ public class MappedStatementConfig {
     }
     statement.setId(id);
     statement.setResource(errorContext.getResource());
-    if (resultSetType != null && resultSetType != null) {
+    if (resultSetType != null) {
       switch (resultSetType) {
         case "FORWARD_ONLY":
           statement.setResultSetType(Integer.valueOf(ResultSet.TYPE_FORWARD_ONLY));


### PR DESCRIPTION
one of the earlier changes resulted in accidental duplicate check on result set type which then was combined into same line later.  This simply removes it, it had no value and this doesn't really affect any processing.