### PR TITLE
Wire in support to allow javax or jakarta transaction support transparent to user

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
 
   <groupId>org.mybatis</groupId>
   <artifactId>mybatis2</artifactId>
-  <version>2.7.7-SNAPSHOT</version>
+  <version>2.8.0-SNAPSHOT</version>
 
   <name>mybatis2</name>
   <description>The mybatis data mapper framework makes it easier to use a relational database with object-oriented
@@ -128,10 +128,19 @@
       <scope>provided</scope>
     </dependency>
 
+    <!-- Provided for javax namespace -->
+    <dependency>
+      <groupId>javax.transaction</groupId>
+      <artifactId>javax.transaction-api</artifactId>
+      <version>1.3</version>
+      <scope>provided</scope>
+    </dependency>
+
+    <!-- Provided for jakarta namespace -->
     <dependency>
       <groupId>jakarta.transaction</groupId>
       <artifactId>jakarta.transaction-api</artifactId>
-      <version>1.3.3</version>
+      <version>2.0.1</version>
       <scope>provided</scope>
     </dependency>
 

--- a/src/main/java/com/ibatis/sqlmap/engine/config/SqlMapConfiguration.java
+++ b/src/main/java/com/ibatis/sqlmap/engine/config/SqlMapConfiguration.java
@@ -40,7 +40,9 @@ import com.ibatis.sqlmap.engine.scope.ErrorContext;
 import com.ibatis.sqlmap.engine.transaction.TransactionManager;
 import com.ibatis.sqlmap.engine.transaction.external.ExternalTransactionConfig;
 import com.ibatis.sqlmap.engine.transaction.jdbc.JdbcTransactionConfig;
-import com.ibatis.sqlmap.engine.transaction.jta.JtaTransactionConfig;
+import com.ibatis.sqlmap.engine.transaction.jta.JTANamespace;
+import com.ibatis.sqlmap.engine.transaction.jta.JakartaTransactionConfig;
+import com.ibatis.sqlmap.engine.transaction.jta.JavaxTransactionConfig;
 import com.ibatis.sqlmap.engine.type.CustomTypeHandler;
 import com.ibatis.sqlmap.engine.type.DomCollectionTypeMarker;
 import com.ibatis.sqlmap.engine.type.DomTypeMarker;
@@ -465,7 +467,8 @@ public class SqlMapConfiguration {
   private void registerDefaultTypeAliases() {
     // TRANSACTION ALIASES
     typeHandlerFactory.putTypeAlias("JDBC", JdbcTransactionConfig.class.getName());
-    typeHandlerFactory.putTypeAlias("JTA", JtaTransactionConfig.class.getName());
+    typeHandlerFactory.putTypeAlias("JTA", JTANamespace.JAKARTA_TRANSACTION_CLASS == null
+        ? JavaxTransactionConfig.class.getName() : JakartaTransactionConfig.class.getName());
     typeHandlerFactory.putTypeAlias("EXTERNAL", ExternalTransactionConfig.class.getName());
 
     // DATA SOURCE ALIASES

--- a/src/main/java/com/ibatis/sqlmap/engine/transaction/jta/JTANamespace.java
+++ b/src/main/java/com/ibatis/sqlmap/engine/transaction/jta/JTANamespace.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2004-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.ibatis.sqlmap.engine.transaction.jta;
+
+/**
+ * The Class JTANamespace.
+ * <p>
+ * Utility class for detecting presence of Jakarta and Javax Transaction API classes.
+ */
+public final class JTANamespace {
+
+  /** The Constant classloader. */
+  private static final ClassLoader classloader = JTANamespace.class.getClassLoader();
+
+  /** The Constant JAKARTA_TRANSACTION_CLASS. */
+  public static final Class<?> JAKARTA_TRANSACTION_CLASS = JTANamespace
+      .searchTypeInClasspath("jakarta.transaction.Transaction");
+
+  /** The Constant JAVAX_TRANSACTION_CLASS. */
+  public static final Class<?> JAVAX_TRANSACTION_CLASS = JTANamespace
+      .searchTypeInClasspath("javax.transaction.Transaction");
+
+  /**
+   * Private constructor to prevent instantiation.
+   */
+  private JTANamespace() {
+    // Utility class
+  }
+
+  /**
+   * Attempts to load the class with the given name using this class's classloader. Returns null if the class is not
+   * found.
+   *
+   * @param <T>
+   *          the generic type
+   * @param typeName
+   *          the type name
+   *
+   * @return the class if found, or null if not found
+   */
+  @SuppressWarnings("unchecked")
+  private static <T> Class<? extends T> searchTypeInClasspath(final String typeName) {
+    try {
+      return (Class<? extends T>) Class.forName(typeName, false, JTANamespace.classloader);
+    } catch (final ClassNotFoundException e) {
+      return null;
+    }
+  }
+
+}

--- a/src/main/java/com/ibatis/sqlmap/engine/transaction/jta/JakartaTransaction.java
+++ b/src/main/java/com/ibatis/sqlmap/engine/transaction/jta/JakartaTransaction.java
@@ -1,0 +1,177 @@
+/*
+ * Copyright 2004-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.ibatis.sqlmap.engine.transaction.jta;
+
+import com.ibatis.common.jdbc.logging.ConnectionLogProxy;
+import com.ibatis.common.logging.Log;
+import com.ibatis.common.logging.LogFactory;
+import com.ibatis.sqlmap.engine.transaction.IsolationLevel;
+import com.ibatis.sqlmap.engine.transaction.Transaction;
+import com.ibatis.sqlmap.engine.transaction.TransactionException;
+
+import jakarta.transaction.Status;
+import jakarta.transaction.UserTransaction;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+
+import javax.sql.DataSource;
+
+/**
+ * The Class JtaTransaction.
+ */
+public class JakartaTransaction implements Transaction {
+
+  /** The Constant connectionLog. */
+  private static final Log connectionLog = LogFactory.getLog(Connection.class);
+
+  /** The user transaction. */
+  private UserTransaction userTransaction;
+
+  /** The data source. */
+  private DataSource dataSource;
+
+  /** The connection. */
+  private Connection connection;
+
+  /** The isolation level. */
+  private IsolationLevel isolationLevel = new IsolationLevel();
+
+  /** The commmitted. */
+  private boolean commmitted = false;
+
+  /** The new transaction. */
+  private boolean newTransaction = false;
+
+  /**
+   * Instantiates a new jta transaction.
+   *
+   * @param utx
+   *          the utx
+   * @param ds
+   *          the ds
+   * @param isolationLevel
+   *          the isolation level
+   *
+   * @throws TransactionException
+   *           the transaction exception
+   */
+  public JakartaTransaction(UserTransaction utx, DataSource ds, int isolationLevel) throws TransactionException {
+    // Check parameters
+    userTransaction = utx;
+    dataSource = ds;
+    if (userTransaction == null) {
+      throw new TransactionException("JtaTransaction initialization failed.  UserTransaction was null.");
+    }
+    if (dataSource == null) {
+      throw new TransactionException("JtaTransaction initialization failed.  DataSource was null.");
+    }
+    this.isolationLevel.setIsolationLevel(isolationLevel);
+  }
+
+  /**
+   * Inits the.
+   *
+   * @throws TransactionException
+   *           the transaction exception
+   * @throws SQLException
+   *           the SQL exception
+   */
+  private void init() throws TransactionException, SQLException {
+    // Start JTA Transaction
+    try {
+      newTransaction = userTransaction.getStatus() == Status.STATUS_NO_TRANSACTION;
+      if (newTransaction) {
+        userTransaction.begin();
+      }
+    } catch (Exception e) {
+      throw new TransactionException("JtaTransaction could not start transaction.  Cause: ", e);
+    }
+
+    // Open JDBC Connection
+    connection = dataSource.getConnection();
+    if (connection == null) {
+      throw new TransactionException(
+          "JtaTransaction could not start transaction.  Cause: The DataSource returned a null connection.");
+    }
+    // Isolation Level
+    isolationLevel.applyIsolationLevel(connection);
+    // AutoCommit
+    if (connection.getAutoCommit()) {
+      connection.setAutoCommit(false);
+    }
+    // Debug
+    if (connectionLog.isDebugEnabled()) {
+      connection = ConnectionLogProxy.newInstance(connection);
+    }
+  }
+
+  @Override
+  public void commit() throws SQLException, TransactionException {
+    if (connection != null) {
+      if (commmitted) {
+        throw new TransactionException(
+            "JtaTransaction could not commit because this transaction has already been committed.");
+      }
+      try {
+        if (newTransaction) {
+          userTransaction.commit();
+        }
+      } catch (Exception e) {
+        throw new TransactionException("JtaTransaction could not commit.  Cause: ", e);
+      }
+      commmitted = true;
+    }
+  }
+
+  @Override
+  public void rollback() throws SQLException, TransactionException {
+    if (connection != null && !commmitted) {
+      try {
+        if (userTransaction != null) {
+          if (newTransaction) {
+            userTransaction.rollback();
+          } else {
+            userTransaction.setRollbackOnly();
+          }
+        }
+      } catch (Exception e) {
+        throw new TransactionException("JtaTransaction could not rollback.  Cause: ", e);
+      }
+    }
+  }
+
+  @Override
+  public void close() throws SQLException, TransactionException {
+    if (connection != null) {
+      try {
+        isolationLevel.restoreIsolationLevel(connection);
+      } finally {
+        connection.close();
+        connection = null;
+      }
+    }
+  }
+
+  @Override
+  public Connection getConnection() throws SQLException, TransactionException {
+    if (connection == null) {
+      init();
+    }
+    return connection;
+  }
+
+}

--- a/src/main/java/com/ibatis/sqlmap/engine/transaction/jta/JakartaTransactionConfig.java
+++ b/src/main/java/com/ibatis/sqlmap/engine/transaction/jta/JakartaTransactionConfig.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2004-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.ibatis.sqlmap.engine.transaction.jta;
+
+import com.ibatis.sqlmap.client.SqlMapException;
+import com.ibatis.sqlmap.engine.transaction.BaseTransactionConfig;
+import com.ibatis.sqlmap.engine.transaction.Transaction;
+import com.ibatis.sqlmap.engine.transaction.TransactionException;
+
+import jakarta.transaction.UserTransaction;
+
+import java.sql.SQLException;
+import java.util.Properties;
+
+import javax.naming.InitialContext;
+import javax.naming.NamingException;
+
+/**
+ * The Class JtaTransactionConfig.
+ */
+public class JakartaTransactionConfig extends BaseTransactionConfig {
+
+  /** The user transaction. */
+  private UserTransaction userTransaction;
+
+  @Override
+  public Transaction newTransaction(int transactionIsolation) throws SQLException, TransactionException {
+    return new JakartaTransaction(userTransaction, dataSource, transactionIsolation);
+  }
+
+  /**
+   * Gets the user transaction.
+   *
+   * @return the user transaction
+   */
+  public UserTransaction getUserTransaction() {
+    return userTransaction;
+  }
+
+  /**
+   * Sets the user transaction.
+   *
+   * @param userTransaction
+   *          the new user transaction
+   */
+  public void setUserTransaction(UserTransaction userTransaction) {
+    this.userTransaction = userTransaction;
+  }
+
+  @Override
+  public void setProperties(Properties props) throws SQLException, TransactionException {
+    String utxName = null;
+    try {
+      utxName = (String) props.get("UserTransaction");
+      InitialContext initCtx = new InitialContext();
+      userTransaction = (UserTransaction) initCtx.lookup(utxName);
+    } catch (NamingException e) {
+      throw new SqlMapException(
+          "Error initializing JtaTransactionConfig while looking up UserTransaction (" + utxName + ").  Cause: " + e);
+    }
+  }
+
+}

--- a/src/main/java/com/ibatis/sqlmap/engine/transaction/jta/JavaxTransaction.java
+++ b/src/main/java/com/ibatis/sqlmap/engine/transaction/jta/JavaxTransaction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2004-2025 the original author or authors.
+ * Copyright 2004-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -32,7 +32,7 @@ import javax.transaction.UserTransaction;
 /**
  * The Class JtaTransaction.
  */
-public class JtaTransaction implements Transaction {
+public class JavaxTransaction implements Transaction {
 
   /** The Constant connectionLog. */
   private static final Log connectionLog = LogFactory.getLog(Connection.class);
@@ -68,7 +68,7 @@ public class JtaTransaction implements Transaction {
    * @throws TransactionException
    *           the transaction exception
    */
-  public JtaTransaction(UserTransaction utx, DataSource ds, int isolationLevel) throws TransactionException {
+  public JavaxTransaction(UserTransaction utx, DataSource ds, int isolationLevel) throws TransactionException {
     // Check parameters
     userTransaction = utx;
     dataSource = ds;

--- a/src/main/java/com/ibatis/sqlmap/engine/transaction/jta/JavaxTransactionConfig.java
+++ b/src/main/java/com/ibatis/sqlmap/engine/transaction/jta/JavaxTransactionConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2004-2025 the original author or authors.
+ * Copyright 2004-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -30,14 +30,14 @@ import javax.transaction.UserTransaction;
 /**
  * The Class JtaTransactionConfig.
  */
-public class JtaTransactionConfig extends BaseTransactionConfig {
+public class JavaxTransactionConfig extends BaseTransactionConfig {
 
   /** The user transaction. */
   private UserTransaction userTransaction;
 
   @Override
   public Transaction newTransaction(int transactionIsolation) throws SQLException, TransactionException {
-    return new JtaTransaction(userTransaction, dataSource, transactionIsolation);
+    return new JavaxTransaction(userTransaction, dataSource, transactionIsolation);
   }
 
   /**


### PR DESCRIPTION
Internal transactional support will now support javax or jakarta based on what is on the classpath with preference to jakarta namespace.  This will be part of version 2.8.0.  In order to pull this off, legacy javax transaction api is being used in provided scope so that both are present to perform compilation here.  Users should only use one as expected.